### PR TITLE
Devops github workflow, update to new node (104.131.175.186) (previou…

### DIFF
--- a/.github/workflows/digitalocean_deploy.yml
+++ b/.github/workflows/digitalocean_deploy.yml
@@ -31,6 +31,6 @@ jobs:
             exit 1
           fi
 
-          ssh -o StrictHostKeyChecking=no -i ssh.key devops@134.209.65.8 \
+          ssh -o StrictHostKeyChecking=no -i ssh.key devops@104.131.175.186 \
             /home/devops/infra/scripts/deploy.sh "$repoDir" "$GITHUB_SHA"
 


### PR DESCRIPTION
Hey @PleatherStarfish 

I've already 'deployed' production to 104.131.175.186, but we are not pointing the domain yet there (hence the quotes around 'deployed'). I've tested the site by updating my pc's hosts file to point bom-squad.com to this IP, and everything looks fine clicking around.

Actually that is a bit odd as I'm expecting the media files to be broken as they are in https://dev.bom-squad.com/? It seems production has links using digitaloceanspaces.com, while dev has links like http://dev.bom-squad.com/media/module_imgs_large_jpeg/module_imgs/outv3_large_6gemZx9.jpg, so possibly this can be ignored.

If you can update the DNS A record for bom-squad.com to the new ip 104.131.175.186, and then merge this branch/commit into `deploy/production` (and `deploy/dev`) that should be all that is needed to have everything setup with the new node. 